### PR TITLE
Remove faulty ramda function

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
 const { resolve } = require('path')
-const { pick, isEmpty, path, assocPath, uniq } = require('ramda')
+const { pick, isEmpty, path, uniq } = require('ramda')
 const { Graph, alg } = require('graphlib')
 const traverse = require('traverse')
 const { utils } = require('@serverless/core')
@@ -17,10 +17,10 @@ const getOutputs = (allComponents) => {
 const resolveObject = (object, context) => {
   const regex = /\${(\w*:?[\w\d.-]+)}/g
 
-  const resolvedObject = traverse(object).reduce(function(accum, value) {
+  const resolvedObject = traverse(object).forEach(function(value) {
     const matches = typeof value === 'string' ? value.match(regex) : null
-    let newValue = value
     if (matches) {
+      let newValue = value
       for (const match of matches) {
         const referencedPropertyPath = match.substring(2, match.length - 1).split('.')
         const referencedPropertyValue = path(referencedPropertyPath, context)
@@ -37,10 +37,9 @@ const resolveObject = (object, context) => {
           throw Error(`the referenced substring is not a string`)
         }
       }
+      this.update(newValue)
     }
-    accum = assocPath(this.path, newValue, accum)
-    return accum
-  }, {})
+  })
 
   return resolvedObject
 }
@@ -84,10 +83,10 @@ const getTemplate = async (inputs) => {
 const resolveTemplate = (template) => {
   const regex = /\${(\w*:?[\w\d.-]+)}/g
   let variableResolved = false
-  const resolvedTemplate = traverse(template).reduce(function(accum, value) {
+  const resolvedTemplate = traverse(template).forEach(function (value) {
     const matches = typeof value === 'string' ? value.match(regex) : null
-    let newValue = value
     if (matches) {
+      let newValue = value
       for (const match of matches) {
         const referencedPropertyPath = match.substring(2, match.length - 1).split('.')
         const referencedTopLevelProperty = referencedPropertyPath[0]
@@ -113,11 +112,9 @@ const resolveTemplate = (template) => {
           }
         }
       }
+      this.update(newValue)
     }
-    accum = assocPath(this.path, newValue, accum)
-
-    return accum
-  }, {})
+  })
   if (variableResolved) {
     return resolveTemplate(resolvedTemplate)
   }


### PR DESCRIPTION
When you have a `serverless.yml` that contains inputs with objects in arrays, the arrays are turned into objects by a ramda function being used.  This causes the component to crash, due to incorrect formatting.  Here is the edge-case of this ramda function: https://github.com/ramda/ramda/issues/1816

For example, deploying any instance of the `aws-dynamodb` component will fail because it requires arrays with objects to define its schema.  However, those arrays will be turned into objects, and the aws sdk will throw an error, causing the component deployment to crash:

```yaml
# serverless.yml

database:
  component: '@serverless/aws-dynamodb@2.0.0'
  inputs:
    region: us-east-1
    attributeDefinitions:
      - AttributeName: 'pk'
        AttributeType: 'S'
      - AttributeName: 'sk'
        AttributeType: 'S'
    keySchema:
      - AttributeName: 'pk'
        KeyType: 'HASH'
      - AttributeName: 'sk'
        KeyType: 'RANGE'
```
To fix this, I just used the `this.update(value)` method that came with the `traverse` module which is already being used.  This seems to work well.