### PR TITLE
Add Support for System Environmental Variables - v1

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -122,10 +122,15 @@ const resolveTemplate = (template) => {
         const referencedTopLevelProperty = referencedPropertyPath[0]
 
         if (!template[referencedTopLevelProperty]) {
-          throw Error(`invalid reference ${match}`)
+          if (process.env[referencedTopLevelProperty]) {
+            newValue = process.env[referencedTopLevelProperty]
+            variableResolved = true
+          } else {
+            throw Error(`invalid reference ${match}`)
+          }
         }
 
-        if (!template[referencedTopLevelProperty].component) {
+        if (!variableResolved && !template[referencedTopLevelProperty].component) {
           variableResolved = true
           const referencedPropertyValue = path(referencedPropertyPath, template)
 


### PR DESCRIPTION
This is version 1. In this version, there are no prefixes in the parameters, if a component is not found with that name, it tries to use an environmental variable.

A dummy test service yaml, executed with `NAME=name STAGE=dev slsdev`
```yaml
name-dev: dev-service
envStage: ${STAGE}
envName: ${NAME}
name: ${${envName}-${envStage}} # first resolves to '${name-dev}' and then to 'dev-service'

# this is just a mock component, it only passes inputs to output
test-component:
  component: "../env-vars"
  inputs:
    stage1: ${STAGE}
    stage2: ${envStage}
    name: ${name}
```

output is 
```shell
  test-component: 
    stage1: dev
    stage2: dev
    name:   dev-service
```