### PR TITLE
Add Support for System Environmental Variables - v2

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -121,24 +121,29 @@ const resolveTemplate = (template) => {
         const referencedPropertyPath = match.substring(2, match.length - 1).split('.')
         const referencedTopLevelProperty = referencedPropertyPath[0]
 
-        if (!template[referencedTopLevelProperty]) {
-          throw Error(`invalid reference ${match}`)
-        }
-
-        if (!template[referencedTopLevelProperty].component) {
+        if (/\${env:(\w*:?[\w\d.-]+)}/g.test(match)) {
+          newValue = process.env[referencedTopLevelProperty.substr(4)]
           variableResolved = true
-          const referencedPropertyValue = path(referencedPropertyPath, template)
-
-          if (referencedPropertyValue === undefined) {
+        } else {
+          if (!template[referencedTopLevelProperty]) {
             throw Error(`invalid reference ${match}`)
           }
 
-          if (match === value) {
-            newValue = referencedPropertyValue
-          } else if (typeof referencedPropertyValue === 'string') {
-            newValue = newValue.replace(match, referencedPropertyValue)
-          } else {
-            throw Error(`the referenced substring is not a string`)
+          if (!template[referencedTopLevelProperty].component) {
+            variableResolved = true
+            const referencedPropertyValue = path(referencedPropertyPath, template)
+
+            if (referencedPropertyValue === undefined) {
+              throw Error(`invalid reference ${match}`)
+            }
+
+            if (match === value) {
+              newValue = referencedPropertyValue
+            } else if (typeof referencedPropertyValue === 'string') {
+              newValue = newValue.replace(match, referencedPropertyValue)
+            } else {
+              throw Error(`the referenced substring is not a string`)
+            }
           }
         }
       }

--- a/utils.js
+++ b/utils.js
@@ -120,9 +120,8 @@ const resolveTemplate = (template) => {
       for (const match of matches) {
         const referencedPropertyPath = match.substring(2, match.length - 1).split('.')
         const referencedTopLevelProperty = referencedPropertyPath[0]
-
-        if (/\${env:(\w*:?[\w\d.-]+)}/g.test(match)) {
-          newValue = process.env[referencedTopLevelProperty.substr(4)]
+        if (/\${env\.(\w*:?[\w\d.-]+)}/g.test(match)) {
+          newValue = process.env[referencedPropertyPath[1]]
           variableResolved = true
         } else {
           if (!template[referencedTopLevelProperty]) {


### PR DESCRIPTION
This is version 2. In this version, the `env.` prefix is used with system environmental variables.

A dummy test service yaml, executed with `NAME=name STAGE=dev slsdev`
```yaml
name-dev: dev-service
envStage: ${env.STAGE}
envName: ${env.NAME}
name: ${${envName}-${envStage}} # first resolves to '${name-dev}' and then to 'dev-service'

# this is just a mock component, it only passes inputs to output
test-component:
  component: "../env-vars"
  inputs:
    stage1: ${env.STAGE}
    stage2: ${envStage}
    name: ${name}
```

output is 
```shell
  test-component: 
    stage1: dev
    stage2: dev
    name:   dev-service
```