### PR TITLE
Add support for custom method invocation on a template file.

### DIFF
--- a/serverless.js
+++ b/serverless.js
@@ -17,13 +17,13 @@ class Template extends Component {
     const defaultFunction = super(id, context)
 
     return new Proxy(defaultFunction, {
-      get: (obj, method) => {
-        if (obj.hasOwnProperty(method)) {
-          return obj[method]
+      get: (obj, prop) => {
+        if (obj.hasOwnProperty(prop)) {
+          return obj[prop]
         }
 
-        // Return a catch-all function that will invoke the custom method on requested components
-        return createCustomMethodHandler(obj, method)
+        // Return a function that will invoke the custom method on requested components
+        return createCustomMethodHandler(obj, prop)
       }
     })
   }

--- a/serverless.js
+++ b/serverless.js
@@ -8,10 +8,26 @@ const {
   createGraph,
   executeGraph,
   syncState,
-  getOutputs
+  getOutputs,
+  createCustomMethodHandler
 } = require('./utils')
 
 class Template extends Component {
+  constructor(id, context) {
+    const defaultFunction = super(id, context)
+
+    return new Proxy(defaultFunction, {
+      get: (obj, method) => {
+        if (obj.hasOwnProperty(method)) {
+          return obj[method]
+        }
+
+        // Return a catch-all function that will invoke the custom method on requested components
+        return createCustomMethodHandler(obj, method)
+      }
+    })
+  }
+
   async default(inputs = {}) {
     this.context.status('Deploying')
 

--- a/utils.js
+++ b/utils.js
@@ -368,7 +368,7 @@ const createCustomMethodHandler = (instance, method) => {
     instance.context.debug(`Verifying presence of method "${method}" in requested components...`)
     for (let i = 0; i < componentsToRun.length; i++) {
       const item = componentsToRun[i]
-      const cmp = await instance.load(item.path)
+      const cmp = await instance.load(item.path, item.alias)
       if (typeof cmp[method] !== 'function') {
         throw Error(`method "${method}" not found in "${item.path}"`)
       }


### PR DESCRIPTION
This PR attempts to solve the problem discussed in issue [#497](https://github.com/serverless/components/issues/497).

This is my take on the problem, @eahefnawy please see the explanation below and let me know if you have a different idea about the implementation:

## Solution
Everything is handled by the `Template` component, so from `cli` perspective nothing is changed.
The cool part is, when `cli` checks if the component has a custom method, and the component happens to be an instance of `Template`, the `Proxy` will return a "proxy" function to execute custom methods . Parameters `--component` are located in the `inputs`, so we can easily treat them equally from both CLI and programmatic perspective.

Below is the example invocation and the resulting output:
![image](https://user-images.githubusercontent.com/3920893/66671146-b71fbb80-ec5b-11e9-97b2-ce7441f7733d.png)

Let me know what you think and if any changes are required 🍻 