### PR TITLE
Ensure to list used dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@serverless/component-metrics": "^1.0.8",
     "@serverless/core": "^1.0.0",
     "graphlib": "^2.1.7",
+    "ramda": "^0.26.1",
     "traverse": "^0.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
It's used at https://github.com/serverless/template/blob/fdc1924136d13e06200917cced8227de53b6d2b3/utils.js#L2 while not referenced in `package.json`.

It works by chance that `@serverless/core` uses it and that most package managers installs deps flat way. Still it may break for some totally valid install scenarios, and also without that we do not guard version we depend on here.

btw. we may consider relying on [@serverless/eslint-config](https://github.com/serverless/eslint-config#serverlesseslint-config) as it'll prevent such setup errors (also having some tests will expose it)
